### PR TITLE
Add more word boundary characters.

### DIFF
--- a/common/head_tag.html
+++ b/common/head_tag.html
@@ -26,7 +26,9 @@
   let keys = Object.keys(words).sort((x,y) => y.length - x.length);
 
   let escapedWords = "((" + keys.map(w => escapeRegExp(w)).join(")|(") + "))";
-  let regex = new RegExp("(\\s|^)+" + escapedWords + "(([:.;,]+(\\s|$))|\\s|$)", "ig");
+  let leftWordBoundary = "(\\s|[\\([{]|^)";
+  let rightWordBoundary = "([:.;,!?…\\]})]|\\s|$)";
+  let regex = new RegExp(leftWordBoundary + escapedWords + rightWordBoundary, "ig");
 
   let createLink = function(text) {
       let lower = text.toLowerCase();


### PR DESCRIPTION
The behavior is now more permissive, we check only single character around the word.

https://meta.discourse.org/t/linkify-words-in-post/82193/67

Apart from what was discussed, I also added the ellipsis character.

I did not added quotation marks yet. From a programmers perspective, I would expect quotation marks to prevent any magic happening to the string (even though I know markdown does not work like that).
@SamSaffron let me know if I should add them.