### PR TITLE
Add excluded_tags theme settings

### DIFF
--- a/common/head_tag.html
+++ b/common/head_tag.html
@@ -24,9 +24,11 @@
   let skipTags = {
     'a': 1,
     'iframe': 1,
-    'code': 1,
-    'pre': 1
   };
+
+  settings.excluded_tags.split('|').forEach(tag => {
+    skipTags[tag] = 1;
+  });
 
   let escapeRegExp = function(str) {
      return str.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&");

--- a/settings.yaml
+++ b/settings.yaml
@@ -1,3 +1,7 @@
 linked_words:
   type: list
   default: 'discourse,https://www.discourse.org|meta,https://meta.discourse.org'
+excluded_tags:
+  type: list
+  list_type: compact
+  default: 'code|pre'


### PR DESCRIPTION
User-selectable HTML tags that will be excluded from linkifying
The default is the same as before.
<a> and <iframe> are hardcoded