### PR TITLE
FIX: Allow consecutive autolinked words

### DIFF
--- a/common/head_tag.html
+++ b/common/head_tag.html
@@ -47,8 +47,8 @@
      return str.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&");
   }
   
-  let leftWordBoundary = "(\\s|[\\([{]|^)";
-  let rightWordBoundary = "([:.;,!?…\\]})]|\\s|$)";
+  let leftWordBoundary = "(\\s|[:.;,!?…\\([{]|^)";
+  let rightWordBoundary = "(?=[:.;,!?…\\]})]|\\s|$)";
     
   let wordsRegex;
   if (hasWords) { 
@@ -131,15 +131,17 @@
           // got to work backwards not to muck up string
           for (let i = matches.length - 1; i >= 0; i--) {
             match = matches[i];
-            text.splitText(match.index + match[1].length);
-            text.nextSibling.splitText(match[2].length);
+            let matched_left_boundary = match[1];
+            let matched_word = match[2];
+            text.splitText(match.index + matched_left_boundary.length);
+            text.nextSibling.splitText(matched_word.length);
             // Did we capture user defined variables?
-            // By default, we capture 3 vars: left boundary, the regex itself, right boundary
+            // By default, we capture 2 vars: left boundary and the regex itself
             let capturedVariables = [];
-            if (match.length > 4) {
-              capturedVariables = match.slice(3, match.length-1);
+            if (match.length > 3) {
+              capturedVariables = match.slice(3, match.length);
             }
-            text.parentNode.replaceChild(createLinkFromRegex(match[2], regex, capturedVariables), text.nextSibling);
+            text.parentNode.replaceChild(createLinkFromRegex(matched_word, regex, capturedVariables), text.nextSibling);
           }
       }
   }


### PR DESCRIPTION
Before this fix, if words were right next to each other (separated only by one char), only the first would be autolinked. I've also added some more left-boundary chars, we do not have to be so strict...

This was part of #7 that needed to be reverted. I'll have some ideas about how to fix rest of #7, will push another PR hopefully this week.