### PR TITLE
FIX: Handle multiple matches of the same word

### DIFF
--- a/common/head_tag.html
+++ b/common/head_tag.html
@@ -69,11 +69,11 @@
   };
 
   let prepareRegex = function(input) {
-      let word_or_regex, modifier, regex;
+      let wordOrRegex, modifier, regex;
       if (isInputRegex(input)) {
         let tmp = input.split('/');
         modifier = tmp.pop();
-        word_or_regex = tmp.slice(1).join('/');
+        wordOrRegex = tmp.slice(1).join('/');
         // Allow only "i" modifier for now, global modifier is implicit
         if (modifier.includes('i')) {
           modifier = 'ig';
@@ -85,10 +85,10 @@
         // Autolink only first occurence of the word in paragraph,
         // i.e. do not use global modifier here
         modifier = 'i';
-        word_or_regex = escapeRegExp(input);
+        wordOrRegex = escapeRegExp(input);
       }
       try {
-        regex = new RegExp(leftWordBoundary + '(' + word_or_regex + ')' + rightWordBoundary, modifier);
+        regex = new RegExp(leftWordBoundary + '(' + wordOrRegex + ')' + rightWordBoundary, modifier);
       }
       catch(err) {
         console.log("ERROR from auto-linkify theme: Invalid input:");
@@ -116,9 +116,13 @@
   }
 
   let autolink = function(text) {
-    // sort words longest first so regex matches first
-    // (does not really make sense for regex input)
-    let keys = Object.keys(words).sort((x,y) => y.length - x.length);
+    let inputRegexes = Object.keys(words).filter(isInputRegex);
+    // sort words longest first
+    let sortedWords = Object.keys(words)
+                      .filter(x => !isInputRegex(x))
+                      .sort((x,y) => y.length - x.length);
+    // First match regexes in the original order, then words longest first
+    let keys = inputRegexes.concat(sortedWords);
     let matches = [];
     for (let i = 0; i < keys.length; i++) {
       let input = keys[i];
@@ -131,17 +135,21 @@
     sortedMatches = matches.sort((m, n) => n.index - m.index);
     for (let i = 0; i < sortedMatches.length; i++) {
       match = sortedMatches[i];
-      let matched_left_boundary = match[1];
-      let matched_word = match[2];
-      text.splitText(match.index + matched_left_boundary.length);
-      text.nextSibling.splitText(matched_word.length);
+      let matchedLeftBoundary = match[1];
+      let matchedWord = match[2];
+      // We need to protect against multiple matches of the same word or phrase
+      if (match.index + matchedLeftBoundary.length + matchedWord.length > text.data.length) {
+        continue;
+      }
+      text.splitText(match.index + matchedLeftBoundary.length);
+      text.nextSibling.splitText(matchedWord.length);
       // Did we capture user defined variables?
       // By default, we capture 2 vars: left boundary and the regex itself
       let capturedVariables = [];
       if (match.length > 3) {
         capturedVariables = match.slice(3, match.length);
       }
-      text.parentNode.replaceChild(createLink(matched_word, match.url, capturedVariables), text.nextSibling);
+      text.parentNode.replaceChild(createLink(matchedWord, match.url, capturedVariables), text.nextSibling);
     }
   }
 


### PR DESCRIPTION
Handle corner case where a single word is matched more than once. This can happen if there are duplicities in the `linked words` input list, perhaps like this:

```
word, url1
/regex_matching_word/, url2
```