### PR TITLE
FEATURE: New excluded classes setting.

### DIFF
--- a/javascripts/discourse-linkify/initializers/initialize-discourse-linkify.js.es6
+++ b/javascripts/discourse-linkify/initializers/initialize-discourse-linkify.js.es6
@@ -54,7 +54,7 @@ export default {
             traverseNodes($elem[0], action, skipTags, skipClasses)
           }
         });
-      });
+      }, {'id': 'linkify-words-theme'});
     });
   }
 }

--- a/javascripts/discourse-linkify/initializers/initialize-discourse-linkify.js.es6
+++ b/javascripts/discourse-linkify/initializers/initialize-discourse-linkify.js.es6
@@ -1,8 +1,8 @@
 import { withPluginApi } from "discourse/lib/plugin-api";
-import { modifyNode, readInputList} from '../lib/utilities'; 
+import { traverseNodes, readInputList} from '../lib/utilities';
 
 export default {
-  name: 'my-initializer',
+  name: 'discourse-linkify-initializer',
   initialize(){
     withPluginApi("0.8.7", api => {
 
@@ -16,6 +16,15 @@ export default {
         tag = tag.trim().toLowerCase();
         if (tag !== '') {
           skipTags[tag] = 1;
+        }
+      });
+
+      let skipClasses = {};
+
+      settings.excluded_classes.split('|').forEach(cls => {
+        cls = cls.trim().toLowerCase();
+        if (cls !== '') {
+          skipClasses[cls] = 1;
         }
       });
       
@@ -40,9 +49,9 @@ export default {
       actions.forEach(readInputList);
         
       api.decorateCooked($elem => {
-        actions.forEach(a => {
-          if (Object.keys(a.inputs).length > 0) {
-            modifyNode($elem[0], a, skipTags)
+        actions.forEach(action => {
+          if (Object.keys(action.inputs).length > 0) {
+            traverseNodes($elem[0], action, skipTags, skipClasses)
           }
         });
       });

--- a/javascripts/discourse-linkify/lib/utilities.js.es6
+++ b/javascripts/discourse-linkify/lib/utilities.js.es6
@@ -126,14 +126,28 @@ const modifyText = function(text, action) {
   }
 }
 
-const modifyNode = function(elem, action, skipTags) {
+const isSkippedClass = function(classes, skipClasses) {
+
+  if (!classes) return false;
+
+  // Return true if at least one of the classes should be skipped
+  return classes.split(" ").some(cls => {
+    for (let skipClass in skipClasses) {
+      if (cls === skipClass) return true;
+    }
+    return false;
+  });
+}
+
+const traverseNodes = function(elem, action, skipTags, skipClasses) {
   // work backwards so changes do not break iteration
   for(let i = elem.childNodes.length - 1; i >=0; i--) {
     let child = elem.childNodes[i];
     if (child.nodeType === 1) {
       let tag = child.nodeName.toLowerCase();
-      if (!(tag in skipTags)) {
-        modifyNode(child, action, skipTags);
+      let cls = child.getAttribute("class");
+      if (!(tag in skipTags) && !isSkippedClass(cls, skipClasses)) {
+        traverseNodes(child, action, skipTags);
       }
     } else if (child.nodeType === 3) {
       modifyText(child, action);
@@ -141,4 +155,4 @@ const modifyNode = function(elem, action, skipTags) {
   }
 }
 
-export {readInputList, modifyNode}
+export {readInputList, traverseNodes}

--- a/javascripts/discourse-linkify/lib/utilities.js.es6
+++ b/javascripts/discourse-linkify/lib/utilities.js.es6
@@ -127,16 +127,9 @@ const modifyText = function(text, action) {
 }
 
 const isSkippedClass = function(classes, skipClasses) {
-
-  if (!classes) return false;
-
+  if (!classes || !skipClasses) return false;
   // Return true if at least one of the classes should be skipped
-  return classes.split(" ").some(cls => {
-    for (let skipClass in skipClasses) {
-      if (cls === skipClass) return true;
-    }
-    return false;
-  });
+  return classes.split(" ").some(cls => cls in skipClasses);
 }
 
 const traverseNodes = function(elem, action, skipTags, skipClasses) {

--- a/javascripts/discourse-linkify/lib/utilities.js.es6
+++ b/javascripts/discourse-linkify/lib/utilities.js.es6
@@ -127,7 +127,7 @@ const modifyText = function(text, action) {
 }
 
 const isSkippedClass = function(classes, skipClasses) {
-  if (!classes || !skipClasses) return false;
+  if (!classes) return false;
   // Return true if at least one of the classes should be skipped
   return classes.split(" ").some(cls => cls in skipClasses);
 }
@@ -140,7 +140,7 @@ const traverseNodes = function(elem, action, skipTags, skipClasses) {
       let tag = child.nodeName.toLowerCase();
       let cls = child.getAttribute("class");
       if (!(tag in skipTags) && !isSkippedClass(cls, skipClasses)) {
-        traverseNodes(child, action, skipTags);
+        traverseNodes(child, action, skipTags, skipClasses);
       }
     } else if (child.nodeType === 3) {
       modifyText(child, action);

--- a/javascripts/discourse-linkify/lib/utilities.js.es6
+++ b/javascripts/discourse-linkify/lib/utilities.js.es6
@@ -127,9 +127,8 @@ const modifyText = function(text, action) {
 }
 
 const isSkippedClass = function(classes, skipClasses) {
-  if (!classes) return false;
   // Return true if at least one of the classes should be skipped
-  return classes.split(" ").some(cls => cls in skipClasses);
+  return classes && classes.split(" ").some(cls => cls in skipClasses);
 }
 
 const traverseNodes = function(elem, action, skipTags, skipClasses) {

--- a/settings.yaml
+++ b/settings.yaml
@@ -5,3 +5,7 @@ excluded_tags:
   type: list
   list_type: compact
   default: 'code|pre'
+excluded_classes:
+  type: list
+  list_type: compact
+  default: 'onebox'


### PR DESCRIPTION
As per user request on meta: https://meta.discourse.org/t/linkify-words-in-post/82193/160?u=danekhollas

By default, we will not autolink inside oneboxes.

The easiest way to test this is in quotes, by adding `quote` as an excluded class.

![image](https://user-images.githubusercontent.com/9539441/75583097-46900480-5a6d-11ea-8a59-285350fdf07c.png)

FYI @SamSaffron 