### PR TITLE
Adds an excluded attributes list

### DIFF
--- a/javascripts/discourse-linkify/initializers/initialize-discourse-linkify.js
+++ b/javascripts/discourse-linkify/initializers/initialize-discourse-linkify.js
@@ -28,6 +28,15 @@ export default {
         }
       });
 
+      let skipAttributes = {};
+
+      settings.excluded_attributes.split("|").forEach((attr) => {
+        attr = attr.trim().toLowerCase();
+        if (attr !== "") {
+          skipAttributes[attr] = 1;
+        }
+      });
+
       let createLink = function (text, url) {
         let link = document.createElement("a");
         link.innerHTML = text;
@@ -52,7 +61,7 @@ export default {
         (element) => {
           actions.forEach((action) => {
             if (Object.keys(action.inputs).length > 0) {
-              traverseNodes(element, action, skipTags, skipClasses);
+              traverseNodes(element, action, skipTags, skipClasses, skipAttributes);
             }
           });
         },

--- a/javascripts/discourse-linkify/lib/utilities.js
+++ b/javascripts/discourse-linkify/lib/utilities.js
@@ -143,15 +143,26 @@ const isSkippedClass = function (classes, skipClasses) {
   return classes && classes.split(" ").some((cls) => cls in skipClasses);
 };
 
-const traverseNodes = function (elem, action, skipTags, skipClasses) {
+const isSkippedAttribute = function (attributes, skipAttributes) {
+  // Return true if at least one of the attributes should be skipped
+  for(var i = attributes.length - 1; i >= 0; i--) {
+    if (attributes[i].name in skipAttributes) {
+      return true;
+    }
+  }
+  return false;
+};
+
+const traverseNodes = function (elem, action, skipTags, skipClasses, skipAttributes) {
   // work backwards so changes do not break iteration
   for (let i = elem.childNodes.length - 1; i >= 0; i--) {
     let child = elem.childNodes[i];
     if (child.nodeType === 1) {
       let tag = child.nodeName.toLowerCase();
       let cls = child.getAttribute("class");
-      if (!(tag in skipTags) && !isSkippedClass(cls, skipClasses)) {
-        traverseNodes(child, action, skipTags, skipClasses);
+      let attr = child.attributes;
+      if (!(tag in skipTags) && !isSkippedClass(cls, skipClasses) && !isSkippedAttribute(attr, skipAttributes)) {
+        traverseNodes(child, action, skipTags, skipClasses, skipAttributes);
       }
     } else if (child.nodeType === 3) {
       modifyText(child, action);

--- a/settings.yaml
+++ b/settings.yaml
@@ -9,3 +9,7 @@ excluded_classes:
   type: list
   list_type: compact
   default: "onebox"
+excluded_attributes:
+  type: list
+  list_type: compact
+  default: "data-nolinkify"


### PR DESCRIPTION
Adds an attribute list to exclude terms from being linkified.

It allows more flexibility to prevent terms from being linkified since we can add any "data-whatever" attributes to any HTML element in the composer, while Discourse doesn't allow any custom class.