### PR TITLE
Fix pipe delimiter and word boundary

### DIFF
--- a/javascripts/discourse-linkify/lib/utilities.js
+++ b/javascripts/discourse-linkify/lib/utilities.js
@@ -6,7 +6,8 @@ const readInputList = function (action) {
     if (!pair.includes(",")) {
       return;
     }
-    let split = pair.split(",");
+    let re = new RegExp(escapeRegExp(settings.regex_substitute_or_character.charAt(0)), "g");
+    let split = pair.replace(re, "|").split(",");
     let value = split.pop().trim();
     // We want to allow commas in regexes
     let word = split.join(",").trim();
@@ -31,8 +32,17 @@ const escapeRegExp = function (str) {
 };
 
 const prepareRegex = function (input) {
-  let leftWordBoundary = "(\\s|[:.;,!?…\\([{]|^)";
-  let rightWordBoundary = "(?=[:.;,!?…\\]})]|\\s|$)";
+  let leftWordBoundary = "(\\b)";
+  let rightWordBoundary = "(\\b)";
+  if (settings.match_at_word_boundary) {
+    if (settings.underscore_as_word_boundary) {
+      leftWordBoundary = "(\\b|_)";
+      rightWordBoundary = "(\\b|_)";
+    }
+  } else {
+    leftWordBoundary = "()";
+    rightWordBoundary = "()";
+  }
   let wordOrRegex, modifier, regex;
   if (isInputRegex(input)) {
     let tmp = input.split("/");

--- a/settings.yaml
+++ b/settings.yaml
@@ -9,3 +9,9 @@ excluded_classes:
   type: list
   list_type: compact
   default: "onebox"
+regex_substitute_or_character:
+  default: "¦"
+match_at_word_boundary:
+  default: true
+underscore_as_word_boundary:
+  default: false


### PR DESCRIPTION
- standard word boundary list (with optional `_` as boundary) instead of hardcoded ones
- a substitute character for Regex `|` (configurable, with default `¦`) for rules input (replaced back to `|` in code)